### PR TITLE
Batch analysis + metadata-alongside-audio

### DIFF
--- a/tests/test_batch_analyze.py
+++ b/tests/test_batch_analyze.py
@@ -1,0 +1,68 @@
+"""Tests for batch analysis script and metadata resolution."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "visuals" / "scripts"))
+
+from batch_analyze import parse_bpm, find_stem
+
+
+class TestParseBpm:
+    def test_standard_format(self):
+        assert parse_bpm("BlueMonday_130_Em") == 130
+
+    def test_three_digit_bpm(self):
+        assert parse_bpm("CrystalCastlesVsHealth_148_Em") == 148
+
+    def test_two_digit_bpm(self):
+        assert parse_bpm("SomeTrack_90_Am") == 90
+
+    def test_no_bpm(self):
+        assert parse_bpm("JustAName") is None
+
+    def test_non_numeric(self):
+        assert parse_bpm("Track_fast_Em") is None
+
+
+class TestFindStem:
+    def test_finds_matching_stem(self, tmp_path):
+        (tmp_path / "3_Drums_Track.wav").touch()
+        assert find_stem(tmp_path, "3_Drums") is not None
+
+    def test_returns_none_if_missing(self, tmp_path):
+        (tmp_path / "4_Mix_Track.wav").touch()
+        assert find_stem(tmp_path, "3_Drums") is None
+
+
+class TestResolveTrackMetadata:
+    def test_finds_metadata_in_track_dir(self, tmp_path):
+        sys.path.insert(0, str(Path(__file__).parent.parent / "visuals" / "scripts"))
+        from generate_video import resolve_track_metadata
+
+        # Create a fake track dir with audio and metadata
+        audio = tmp_path / "4_Mix_Track.wav"
+        audio.touch()
+        phrases = tmp_path / "phrases.json"
+        phrases.write_text('{"sections": []}')
+        snare = tmp_path / "snare.json"
+        snare.write_text('{"snare_times": []}')
+
+        p, s = resolve_track_metadata(str(audio))
+        assert p is not None
+        assert s is not None
+        assert p.name == "phrases.json"
+        assert s.name == "snare.json"
+
+    def test_returns_none_when_no_metadata(self, tmp_path):
+        from generate_video import resolve_track_metadata
+
+        audio = tmp_path / "4_Mix_Track.wav"
+        audio.touch()
+
+        p, s = resolve_track_metadata(str(audio))
+        assert p is None
+        assert s is None

--- a/visuals/scripts/batch_analyze.py
+++ b/visuals/scripts/batch_analyze.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Batch analysis: run phrase detection + snare detection for all tracks.
+
+Walks audio/library/<TrackName>/ directories and writes metadata alongside
+the audio files:
+  - phrases.json   (phrase/beat/section data from phrase_detect.py)
+  - snare.json     (snare hit times from detect_snare.py)
+
+Metadata lives with the audio, not in git.  Both sync to R2 together.
+
+Usage:
+  python visuals/scripts/batch_analyze.py                  # all tracks
+  python visuals/scripts/batch_analyze.py --track BlueMonday_130_Em
+  python visuals/scripts/batch_analyze.py --force           # overwrite existing
+  python visuals/scripts/batch_analyze.py --phrases-only    # skip snare
+  python visuals/scripts/batch_analyze.py --snare-only      # skip phrases
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Add parent so we can import sibling modules
+sys.path.insert(0, str(Path(__file__).parent))
+
+from phrase_detect import analyze as phrase_analyze
+from detect_snare import detect_snare
+
+import numpy as np
+
+DEFAULT_LIBRARY = Path(__file__).parent.parent.parent / "audio" / "library"
+
+
+def find_stem(track_dir: Path, prefix: str) -> Path | None:
+    """Find a stem WAV by prefix (e.g. '3_Drums', '4_Mix')."""
+    matches = list(track_dir.glob(f"{prefix}_*.wav"))
+    return matches[0] if matches else None
+
+
+def run_phrases(track_dir: Path, track_name: str, bpm: int | None,
+                force: bool) -> dict | None:
+    """Run phrase detection on the mix stem. Returns phrase data or None."""
+    out = track_dir / "phrases.json"
+    if out.exists() and not force:
+        print(f"  [skip] {track_name}/phrases.json exists (use --force)")
+        return json.loads(out.read_text())
+
+    mix = find_stem(track_dir, "4_Mix")
+    if not mix:
+        print(f"  [warn] {track_name}: no 4_Mix stem, skipping phrases")
+        return None
+
+    print(f"  Analyzing phrases: {mix.name}")
+    result = phrase_analyze(str(mix), bpm=bpm)
+
+    out.write_text(json.dumps(result, indent=2))
+    n_sections = len(result.get("sections", []))
+    print(f"  -> {out.name}: {n_sections} sections, "
+          f"{result['total_beats']} beats")
+    return result
+
+
+def run_snare(track_dir: Path, track_name: str, phrases: dict,
+              force: bool) -> None:
+    """Run snare detection on the drum stem."""
+    out = track_dir / "snare.json"
+    if out.exists() and not force:
+        print(f"  [skip] {track_name}/snare.json exists (use --force)")
+        return
+
+    drums = find_stem(track_dir, "3_Drums")
+    if not drums:
+        print(f"  [warn] {track_name}: no 3_Drums stem, skipping snare")
+        return
+
+    beat_times = np.array(phrases["beat_times"])
+    beat_interval = float(np.median(np.diff(beat_times)))
+
+    print(f"  Detecting snare: {drums.name}")
+    times, snare_idx = detect_snare(str(drums), beat_interval, beat_times)
+
+    out.write_text(json.dumps({
+        "snare_times": times,
+        "n_hits": len(times),
+        "drum_stem": str(drums),
+        "method": "nmf_pcen",
+        "snare_component": snare_idx,
+    }, indent=2))
+    print(f"  -> {out.name}: {len(times)} hits")
+
+
+def parse_bpm(track_name: str) -> int | None:
+    """Extract BPM from track directory name like 'BlueMonday_130_Em'."""
+    parts = track_name.rsplit("_", 2)
+    if len(parts) >= 3:
+        try:
+            return int(parts[-2])
+        except ValueError:
+            pass
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Batch phrase + snare analysis")
+    ap.add_argument("--library", type=Path, default=DEFAULT_LIBRARY,
+                    help=f"Audio library path (default: {DEFAULT_LIBRARY})")
+    ap.add_argument("--track", help="Analyze only this track dir name")
+    ap.add_argument("--force", action="store_true",
+                    help="Overwrite existing metadata")
+    ap.add_argument("--phrases-only", action="store_true",
+                    help="Run phrase detection only (skip snare)")
+    ap.add_argument("--snare-only", action="store_true",
+                    help="Run snare detection only (skip phrases)")
+    args = ap.parse_args()
+
+    library = args.library.resolve()
+    if not library.exists():
+        raise SystemExit(f"Audio library not found: {library}")
+
+    # Collect track directories
+    if args.track:
+        track_dirs = [library / args.track]
+        if not track_dirs[0].is_dir():
+            raise SystemExit(f"Track not found: {track_dirs[0]}")
+    else:
+        track_dirs = sorted(
+            d for d in library.iterdir()
+            if d.is_dir() and not d.name.startswith(".")
+        )
+
+    print(f"Batch analysis: {len(track_dirs)} tracks in {library}\n")
+
+    stats = {"phrases": 0, "snare": 0, "skipped": 0, "errors": 0}
+
+    for track_dir in track_dirs:
+        name = track_dir.name
+        bpm = parse_bpm(name)
+        print(f"\n[{name}]  BPM={bpm or '?'}")
+
+        try:
+            # Phrase detection
+            phrases = None
+            if not args.snare_only:
+                phrases = run_phrases(track_dir, name, bpm, args.force)
+                if phrases:
+                    stats["phrases"] += 1
+
+            # Snare detection (needs phrases for beat grid)
+            if not args.phrases_only:
+                if phrases is None:
+                    # Try loading existing phrases.json for snare-only mode
+                    pf = track_dir / "phrases.json"
+                    if pf.exists():
+                        phrases = json.loads(pf.read_text())
+
+                if phrases and "beat_times" in phrases:
+                    run_snare(track_dir, name, phrases, args.force)
+                    stats["snare"] += 1
+                elif not args.phrases_only:
+                    print(f"  [skip] No phrase data for snare detection")
+                    stats["skipped"] += 1
+
+        except Exception as e:
+            print(f"  [ERROR] {name}: {e}")
+            stats["errors"] += 1
+
+    print(f"\n{'='*50}")
+    print(f"Done. phrases={stats['phrases']}  snare={stats['snare']}  "
+          f"skipped={stats['skipped']}  errors={stats['errors']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visuals/scripts/generate_video.py
+++ b/visuals/scripts/generate_video.py
@@ -38,6 +38,25 @@ DEFAULT_OUTPUT  = _PROJECT / "output/live-visuals/blue_monday_v1.mp4"
 MOTION_MAX = 0.243
 
 
+def resolve_track_metadata(audio_path: str) -> tuple[Path | None, Path | None]:
+    """Auto-resolve phrases.json and snare.json from the track directory.
+
+    If --audio points to a file inside audio/library/<TrackName>/,
+    look for phrases.json and snare.json alongside the audio.
+    Returns (phrases_path, snare_path) — either may be None.
+    """
+    audio = Path(audio_path).resolve()
+    track_dir = audio.parent
+
+    phrases = track_dir / "phrases.json"
+    snare = track_dir / "snare.json"
+
+    return (
+        phrases if phrases.exists() else None,
+        snare if snare.exists() else None,
+    )
+
+
 # ── section characterization ──────────────────────────────────────────────────
 
 def compute_thresholds(sections):
@@ -885,6 +904,15 @@ def main():
 
     rng = random.Random(args.seed)
     w, h = (854, 480) if args.preview else (W, H)
+
+    # Auto-resolve metadata from track directory if not explicitly provided
+    auto_phrases, auto_snare = resolve_track_metadata(args.audio)
+    if args.phrases == str(DEFAULT_PHRASES) and auto_phrases:
+        print(f"  Auto-resolved phrases: {auto_phrases}")
+        args.phrases = str(auto_phrases)
+    if args.snare is None and auto_snare:
+        print(f"  Auto-resolved snare: {auto_snare}")
+        args.snare = str(auto_snare)
 
     print("Loading data...")
     phrases    = json.loads(Path(args.phrases).read_text())

--- a/visuals/scripts/phrase_detect.py
+++ b/visuals/scripts/phrase_detect.py
@@ -13,7 +13,12 @@ Peaks in the impact curve = likely section boundaries.
 import argparse, json
 import numpy as np
 import librosa
-import essentia.standard as es
+
+try:
+    import essentia.standard as es
+    HAS_ESSENTIA = True
+except ImportError:
+    HAS_ESSENTIA = False
 
 def snap_to_bar(beat_idx, total_beats, bar_len=4):
     """Snap a beat index to the nearest bar boundary."""
@@ -48,26 +53,34 @@ def analyze(audio_path: str, bpm: float = None, n_sections: int = None,
     duration = len(y) / sr
     print(f"Duration: {duration:.1f}s  SR: {sr}")
 
-    # beat tracking via Essentia RhythmExtractor2013 (more accurate than librosa)
-    print("  Beat tracking (Essentia RhythmExtractor2013)...")
-    rhythm = es.RhythmExtractor2013(method="multifeature")
-    if bpm:
-        # constrain to known BPM ±2%
-        bpm_tol = bpm * 0.02
-        tempo_est, beat_times_es, _, _, _ = rhythm(y)
-        # if detected tempo is off, recompute with librosa at fixed BPM
-        if abs(tempo_est - bpm) > bpm_tol * 2:
-            print(f"  Essentia tempo {tempo_est:.1f} differs from --bpm {bpm}, using fixed BPM")
-            beat_times_arr = librosa.beat.beat_track(y=y, sr=sr, bpm=bpm, units='time')[1]
-            beat_times = np.array(beat_times_arr)
-            tempo = bpm
+    # beat tracking: Essentia if available, else librosa
+    if HAS_ESSENTIA:
+        print("  Beat tracking (Essentia RhythmExtractor2013)...")
+        rhythm = es.RhythmExtractor2013(method="multifeature")
+        if bpm:
+            bpm_tol = bpm * 0.02
+            tempo_est, beat_times_es, _, _, _ = rhythm(y)
+            if abs(tempo_est - bpm) > bpm_tol * 2:
+                print(f"  Essentia tempo {tempo_est:.1f} differs from --bpm {bpm}, using librosa")
+                beat_times_arr = librosa.beat.beat_track(y=y, sr=sr, bpm=bpm, units='time')[1]
+                beat_times = np.array(beat_times_arr)
+                tempo = bpm
+            else:
+                beat_times = np.array(beat_times_es)
+                tempo = float(tempo_est)
         else:
+            tempo_est, beat_times_es, _, _, _ = rhythm(y)
             beat_times = np.array(beat_times_es)
             tempo = float(tempo_est)
     else:
-        tempo_est, beat_times_es, _, _, _ = rhythm(y)
-        beat_times = np.array(beat_times_es)
-        tempo = float(tempo_est)
+        print("  Beat tracking (librosa)...")
+        if bpm:
+            tempo = bpm
+            _, beat_frames_lib = librosa.beat.beat_track(y=y, sr=sr, bpm=bpm)
+        else:
+            tempo_est, beat_frames_lib = librosa.beat.beat_track(y=y, sr=sr)
+            tempo = float(tempo_est.item() if hasattr(tempo_est, 'item') else tempo_est)
+        beat_times = librosa.frames_to_time(beat_frames_lib, sr=sr)
 
     beat_frames = librosa.time_to_frames(beat_times, sr=sr)
     print(f"  Tempo: {tempo:.1f} BPM, {len(beat_times)} beats detected")


### PR DESCRIPTION
## Summary
- Metadata (phrases.json, snare.json) now lives in `audio/library/<TrackName>/` alongside audio — both gitignored, both sync to R2
- New `batch_analyze.py` script runs phrase + snare detection across all 52 tracks
- `phrase_detect.py` essentia fallback to librosa (unblocks CI where essentia has no wheels)
- `generate_video.py` auto-resolves metadata from the audio file's parent directory

## Test plan
- [x] 30/30 tests pass (21 compositing + 9 batch analysis)
- [x] Batch analyzer tested on BlueMonday (skip existing) and DAF (fresh analysis)
- [x] Librosa fallback produces valid phrase data without essentia

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)