### PR TITLE
Design modes, still tagging, and render tuning

### DIFF
--- a/projects/funeral_parade_of_roses/DESIGN.md
+++ b/projects/funeral_parade_of_roses/DESIGN.md
@@ -50,14 +50,40 @@ venv/bin/python visuals/scripts/generate_video.py \
 
 ---
 
-## Audio-Reactive Brightness
+## Design Modes
 
-Video layer brightness correlates with audio volume:
-- Silence → video goes black
-- Exponential release (default 1.0s) — doesn't instantly cut on quiet passages
-- **Does NOT affect 2D stills** — stills are overlaid after brightness stage
+A design mode is a coherent set of rules governing brightness, color, and framing. Each mode produces a distinct visual character from the same source material. Select with `--white-mode` (default is black mode).
 
-CLI: `--brightness-release 1.0` / `--no-brightness` to disable
+### Black Mode (default)
+
+| Element | Rule |
+|---|---|
+| Brightness blend | `multiply` — silence → black, loud → full brightness |
+| Envelope floor | 0.0 (true black in silence) |
+| Pillarbox bars | Black |
+| Snare flash | contrast=2.2, brightness=+0.06, 80ms |
+| Layer blend | `screen` at 0.45 opacity (layer 2 at 0.6× = 0.27) |
+| Cultural ref | High-contrast B&W film noir; darkness as negative space |
+
+### White Mode (`--white-mode`)
+
+| Element | Rule |
+|---|---|
+| Brightness blend | None — envelope disabled; video plays at full brightness |
+| Envelope floor | N/A |
+| Pillarbox bars | Black (same as all modes) |
+| Snare flash | Same as black mode (contrast=2.2, brightness=+0.06, 80ms) |
+| Layer blend | Same as black mode (`screen` at 0.45 opacity) |
+| Cultural ref | White as Japanese mourning color; overexposed / high-key aesthetic |
+
+### Shared across all modes
+
+- Exponential release (default 1.0s) — volume drops decay gradually, not instantly
+- 2D stills are **not** affected by the brightness envelope — overlaid after brightness stage
+- Strobe modulation (if enabled) applies to the envelope before mode-specific remapping
+- Smoothing window (if set) applies before strobe
+
+CLI: `--brightness-release 1.0` / `--no-brightness` / `--white-mode`
 
 ---
 

--- a/projects/funeral_parade_of_roses/data/review_state.json
+++ b/projects/funeral_parade_of_roses/data/review_state.json
@@ -30,24 +30,24 @@
     "funeral_parade_of_roses_guevaras_delirium/shot_001.mp4": "resplit",
     "funeral_parade_of_roses_guevaras_delirium/shot_004.mp4": "resplit",
     "lf_shot_001.mp4": "ok",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_002.mp4": "resplit",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_003.mp4": "resplit",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_002.mp4": "resplit",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_003.mp4": "resplit",
     "lf_shot_004.mp4": "favorite",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_006.mp4": "resplit",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_007.mp4": "resplit",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_006.mp4": "resplit",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_007.mp4": "resplit",
     "mon_shot_001.mp4": "favorite",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_002.mp4": "resplit",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_003.mp4": "resplit",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_004.mp4": "resplit",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_005.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_002.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_003.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_004.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_005.mp4": "resplit",
     "mon_shot_006.mp4": "favorite",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_007.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_007.mp4": "resplit",
     "mon_shot_008.mp4": "favorite",
     "mon_shot_010.mp4": "favorite",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_011.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_011.mp4": "resplit",
     "mon_shot_012.mp4": "favorite",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_013.mp4": "resplit",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_014.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_013.mp4": "resplit",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_014.mp4": "resplit",
     "mon_shot_015.mp4": "favorite",
     "mon_shot_016.mp4": "favorite",
     "why_shot_002.mp4": "favorite",
@@ -215,18 +215,18 @@
     "funeral_parade_of_roses/shot_005.mp4",
     "funeral_parade_of_roses_guevaras_delirium/shot_001.mp4",
     "funeral_parade_of_roses_guevaras_delirium/shot_004.mp4",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_002.mp4",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_003.mp4",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_006.mp4",
-    "la_femme_si_un_jour_lyrics_english_fran\u00e7ais_music_video_fune/shot_007.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_002.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_003.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_004.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_005.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_007.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_011.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_013.mp4",
-    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_\u8594\u8587\u306e\u846c\u5217/shot_014.mp4",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_002.mp4",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_003.mp4",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_006.mp4",
+    "la_femme_si_un_jour_lyrics_english_français_music_video_fune/shot_007.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_002.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_003.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_004.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_005.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_007.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_011.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_013.mp4",
+    "montage_of_funeral_parade_of_roses_beauty_in_rebellion_薔薇の葬列/shot_014.mp4",
     "why_you_should_watch_funeral_parade_of_roses_1969_late_pride/shot_009.mp4",
     "why_you_should_watch_funeral_parade_of_roses_1969_late_pride/shot_011.mp4",
     "why_you_should_watch_funeral_parade_of_roses_1969_late_pride/shot_018.mp4",
@@ -959,6 +959,108 @@
     "why_shot_107.mp4": [
       "eddie",
       "black"
+    ],
+    "title_interzone_xv.png": [
+      "title",
+      "black"
+    ],
+    "title_funeral_parade.png": [
+      "title",
+      "black"
+    ],
+    "title_interzone_xv_white.png": [
+      "title",
+      "white"
+    ],
+    "title_funeral_parade_white.png": [
+      "title",
+      "white"
+    ],
+    "chrysanthemum_photo_transparent.png": [
+      "black",
+      "white"
+    ],
+    "eddie_big_hair.png": [
+      "eddie",
+      "black"
+    ],
+    "eddie_grain.png": [
+      "eddie",
+      "white"
+    ],
+    "rose_black_on_white.png": [
+      "white"
+    ],
+    "rose_white_on_black.png": [
+      "black"
+    ],
+    "roset_black_on_white.png": [
+      "white"
+    ],
+    "roset_white_on_black.png": [
+      "black"
+    ],
+    "border_symmetric_for_black.png": [
+      "black"
+    ],
+    "border_symmetric_for_white.png": [
+      "white"
+    ],
+    "kanji_chi.png": [
+      "kanji",
+      "black"
+    ],
+    "kanji_kodomo.png": [
+      "kanji",
+      "black"
+    ],
+    "kanji_maboroshi.png": [
+      "kanji",
+      "black"
+    ],
+    "kanji_maigo.png": [
+      "kanji",
+      "black"
+    ],
+    "kanji_okami.png": [
+      "kanji",
+      "black"
+    ],
+    "kanji_shofu.png": [
+      "kanji",
+      "black"
+    ],
+    "kanji_unmei.png": [
+      "kanji",
+      "black"
+    ],
+    "kanji_chi_white.png": [
+      "kanji",
+      "white"
+    ],
+    "kanji_kodomo_white.png": [
+      "kanji",
+      "white"
+    ],
+    "kanji_maboroshi_white.png": [
+      "kanji",
+      "white"
+    ],
+    "kanji_maigo_white.png": [
+      "kanji",
+      "white"
+    ],
+    "kanji_okami_white.png": [
+      "kanji",
+      "white"
+    ],
+    "kanji_shofu_white.png": [
+      "kanji",
+      "white"
+    ],
+    "kanji_unmei_white.png": [
+      "kanji",
+      "white"
     ]
   }
 }

--- a/visuals/compositing.py
+++ b/visuals/compositing.py
@@ -422,8 +422,7 @@ def composite_frame(
                 break  # only one still at a time
 
     # Pillarbox
-    pb_color = 1.0 if white_mode else 0.0
-    result = apply_pillarbox(result, bar_w, color=pb_color)
+    result = apply_pillarbox(result, bar_w, color=0.0)
 
     # Snare contrast flash
     if snare_times:

--- a/visuals/scripts/generate_video.py
+++ b/visuals/scripts/generate_video.py
@@ -13,7 +13,7 @@ Usage:
       --preview   # fast 480p draft
 """
 
-import argparse, json, random, subprocess, tempfile
+import argparse, json, os, random, subprocess, tempfile, time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -580,7 +580,7 @@ def apply_post_composite(
       1          → 2×2 grayscale envelope (piped via stdin), only when envelope is not None
       2..N+1     → still PNG paths (one per schedule entry)
     """
-    pb_color = "white" if white_mode else "black"
+    pb_color = "black"
     pillarbox = (
         f"drawbox=x=0:y=0:w={bar_w}:h=ih:color={pb_color}:t=fill,"
         f"drawbox=x=iw-{bar_w}:y=0:w={bar_w}:h=ih:color={pb_color}:t=fill"
@@ -902,6 +902,8 @@ def main():
                     help="Use legacy ffmpeg filter graph pipeline instead of PyTorch")
     args = ap.parse_args()
 
+    t_start = time.monotonic()
+    timings = {}
     rng = random.Random(args.seed)
     w, h = (854, 480) if args.preview else (W, H)
 
@@ -914,6 +916,7 @@ def main():
         print(f"  Auto-resolved snare: {auto_snare}")
         args.snare = str(auto_snare)
 
+    t_phase = time.monotonic()
     print("Loading data...")
     phrases    = json.loads(Path(args.phrases).read_text())
     shots      = load_shots(args.catalog)
@@ -963,12 +966,15 @@ def main():
             solos.append({'time': t, 'path': path, 'duration': dur})
             print(f"  Solo @ {t:.1f}s: {Path(path).name} ({dur:.1f}s)")
 
+    timings['load'] = time.monotonic() - t_phase
+
     # ── compute shared data (both paths need this) ───────────────────────
     Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     bar_w = int((w - h * PILLARBOX_RATIO) / 2)
 
+    t_phase = time.monotonic()
     envelope = None
-    if not args.no_brightness:
+    if not args.no_brightness and not args.white_mode:
         print("\nComputing brightness envelope...")
         n_frames = int(np.ceil(duration * FPS)) + 4
         envelope = compute_brightness_envelope(
@@ -1000,11 +1006,15 @@ def main():
               f"(max_dur={args.stills_max_dur}s, min_gap={args.stills_min_gap}s)")
 
     snare_times = []
-    if args.snare:
-        snare_data  = json.loads(Path(args.snare).read_text())
-        snare_times = snare_data["snare_times"]
+    # Snare flash disabled globally for now
+    # if args.snare:
+    #     snare_data  = json.loads(Path(args.snare).read_text())
+    #     snare_times = snare_data["snare_times"]
+
+    timings['precompute'] = time.monotonic() - t_phase
 
     # ── build clip lists for all layers ──────────────────────────────────
+    t_phase = time.monotonic()
     all_layer_clips = []
     for li in range(max_layers):
         print(f"\nLayer {li}:")
@@ -1017,6 +1027,9 @@ def main():
         print(f"  {n_cuts} clips, {total:.1f}s")
         all_layer_clips.append(clips)
 
+    timings['clip_build'] = time.monotonic() - t_phase
+
+    t_phase = time.monotonic()
     if args.legacy:
         # ── LEGACY: ffmpeg subprocess pipeline ───────────────────────────
         print("\n[legacy mode] Using ffmpeg filter graph pipeline")
@@ -1108,7 +1121,41 @@ def main():
 
         print(f"  Encode complete → {args.output}")
 
-    print(f"\nDone → {args.output}")
+    timings['render'] = time.monotonic() - t_phase
+    t_total = time.monotonic() - t_start
+
+    # ── performance summary ──────────────────────────────────────────────
+    import resource
+    rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    self_rusage = resource.getrusage(resource.RUSAGE_SELF)
+    peak_mb = (self_rusage.ru_maxrss + rusage.ru_maxrss) / (1024 * 1024)
+    if sys.platform == 'linux':
+        # Linux ru_maxrss is in KB
+        peak_mb = (self_rusage.ru_maxrss + rusage.ru_maxrss) / 1024
+    output_size = Path(args.output).stat().st_size / (1024 * 1024)
+    total_frames = int(np.ceil(duration * FPS))
+
+    print(f"\n{'=' * 60}")
+    print(f"RENDER SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"  Output:      {args.output}")
+    print(f"  Resolution:  {w}x{h}  {'(preview)' if args.preview else '(full)'}")
+    print(f"  Frames:      {total_frames}  ({duration:.1f}s @ {FPS} fps)")
+    print(f"  Pipeline:    {'legacy ffmpeg' if args.legacy else f'PyTorch ({get_device()})'}")
+    print(f"  File size:   {output_size:.1f} MB")
+    print(f"")
+    print(f"  Timings:")
+    print(f"    Load data:     {timings['load']:6.1f}s")
+    print(f"    Precompute:    {timings['precompute']:6.1f}s")
+    print(f"    Clip build:    {timings['clip_build']:6.1f}s")
+    print(f"    Render:        {timings['render']:6.1f}s")
+    print(f"    Total:         {t_total:6.1f}s")
+    print(f"")
+    render_fps = total_frames / timings['render'] if timings['render'] > 0 else 0
+    print(f"  Throughput:  {render_fps:.1f} fps  "
+          f"({timings['render'] / duration:.2f}x realtime)")
+    print(f"  Peak memory: {peak_mb:.0f} MB")
+    print(f"{'=' * 60}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add Design Modes framework to DESIGN.md (black mode / white mode rule tables)
- Tag all 27 still assets with `black`/`white` mode tags in review_state.json
- Fix pillarbox to always be black (even in white mode)
- Disable brightness envelope for white mode, disable snare flash globally
- Add render timing and resource summary block to generate_video.py

## Test plan
- [x] White mode preview renders with correct stills and no envelope
- [x] Snare flash disabled in output
- [x] Pillarbox bars are black in white mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)